### PR TITLE
Try disabling pip's progress bar

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ build:
   script:
   - set PYTHONHASHSEED=0  # [win]
   - export PYTHONHASHSEED=0  # [not win]
-  - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  - "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir --progress-bar off -vvv"
 
 requirements:
   host:


### PR DESCRIPTION
Based on some upstream comments in pip's issue tracker, it looks like pip's progress bar may be in some way related to this unicode path issue on Python 2.7. While it's not entirely clear why that would be the case, this is an easy thing to try with little to no drawbacks.

xref: https://github.com/pypa/pip/issues/5665

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a fork of the feedstock to propose changes
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
